### PR TITLE
[WIP] Add p5 sketches to scene

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
 	<script>
 		window.localStorage.setItem('debug', 'demo-app*');
 	</script>
-	<script src="js/bundle.js"></script>
+
 	<link rel="stylesheet" type="text/css" href="css/main.css">
 	<link rel="shortcut icon" type="image/gif" href="images/favicon.png" />
 
@@ -51,6 +51,8 @@
 </head>
 
 <body>
+	<iframe id='sketchFrame' src="../p5-sketches/aidan-nelson-01/index.html"></iframe>
+	<div id='p5-sketch-container'></div>
 	<div class="full-width-column">
 
 		<div class="main-content-container">
@@ -187,7 +189,7 @@
 
 
 	</div>
-
+	<script src="js/bundle.js"></script>
 </body>
 
 </html>

--- a/public/p5-sketches/aidan-nelson-01/index.html
+++ b/public/p5-sketches/aidan-nelson-01/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.1.9/p5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.1.9/addons/p5.sound.min.js"></script>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <script src="sketch.js"></script>
+</body>
+
+</html>

--- a/public/p5-sketches/aidan-nelson-01/sketch.js
+++ b/public/p5-sketches/aidan-nelson-01/sketch.js
@@ -1,0 +1,184 @@
+let grid;
+let balls = [];
+
+function setup() {
+  createCanvas(500, 500);
+  rectMode(CENTER);
+  for (let i = 0; i < 300; i++) {
+    let b = new Ball(random(-width / 2, width / 2), random(-height / 2, height / 2));
+    balls.push(b);
+  }
+}
+
+
+
+function draw() {
+  let range = 50;
+  background(0, 0, 200);
+  noFill();
+  ellipse(mouseX,mouseY,range*2,range*2);
+  
+  for (let i = 0; i < balls.length; i++) {
+    balls[i].selected = false;
+    balls[i].move();
+  }
+
+  push();
+  translate(width / 2, height / 2);
+
+  grid = new Grid(range, 10);
+  for (let i = 0; i < balls.length; i++) {
+    let ball = balls[i];
+    grid.add(ball.x, ball.y, ball);
+  }
+
+  grid.display();
+  let neighbors = grid.queryAtPoint(mouseX, mouseY);
+  neighbors.forEach((ball) => {
+    ball.selected = true;
+  })
+  
+  
+
+  for (let i = 0; i < balls.length; i++) {
+    balls[i].display();
+  }
+
+  pop();
+}
+
+function mouseClicked() {
+  console.log(grid.queryAtPoint(mouseX, mouseY).length);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class Grid {
+  constructor(cellSize, halfGridSize) {
+
+    this.cellSize = cellSize;
+    this.cellSizeSquared= cellSize*cellSize;
+    this.halfGridSize = halfGridSize;
+    this.grid = []; // our array of arrays of objects
+
+    this.center = {
+      x: 0,
+      y: 0
+    };
+
+    for (let i = -this.halfGridSize; i < this.halfGridSize; i++) {
+      let column = [];
+      for (let j = -this.halfGridSize; j < this.halfGridSize; j++) {
+        column.push([]);
+      }
+      this.grid.push(column);
+    }
+  }
+
+  queryAtPoint(x, y, range) {
+    x -= width / 2;
+    y -= height / 2;
+
+    // console.log(`Querying grid at point ${x},${y}`)
+    let xIndex = this.halfGridSize + floor(x / this.cellSize);
+    let yIndex = this.halfGridSize + floor(y / this.cellSize);
+    // console.log(`Grid index: ${xIndex},${yIndex}`)
+
+    let neighbors = [];
+    for (let i = -1; i <= 1; i++) {
+      for (let j = -1; j <= 1; j++) {
+        if (this.grid[xIndex + i] && this.grid[xIndex + i][yIndex + j]) {
+          neighbors = neighbors.concat(this.grid[xIndex + i][yIndex + j]);
+        }
+      }
+    }
+    
+    neighbors = neighbors.filter((neighbor) => {
+        let distSquared = getDistSquared(x,y,neighbor.x,neighbor.y)
+        return distSquared <= this.cellSizeSquared;
+    })
+    return neighbors;
+  }
+
+  add(x, y, obj) {
+    // console.log(`Adding object at ${x},${y}`)
+    let xIndex = this.halfGridSize + floor(x / this.cellSize);
+    let yIndex = this.halfGridSize + floor(y / this.cellSize);
+
+    if (xIndex > 0 && xIndex < this.halfGridSize * 2 && yIndex >= 0 && yIndex < this.halfGridSize * 2) {
+      this.grid[xIndex][yIndex].push(obj);
+    } else {
+      console.log('Out of bounds!');
+    }
+  }
+
+
+  display() {
+    for (let i = -this.halfGridSize; i < this.halfGridSize; i++) {
+      for (let j = -this.halfGridSize; j < this.halfGridSize; j++) {
+        let centerX = this.center.x + (i * this.cellSize) + this.cellSize / 2;
+        let centerY = this.center.y + (j * this.cellSize) + this.cellSize / 2;
+
+        noFill();
+        stroke(255);
+        strokeWeight(0.25);
+        rect(centerX, centerY, this.cellSize, this.cellSize);
+        fill(0);
+        // ellipse(centerX, centerY, 2, 2);
+
+      }
+    }
+  }
+}
+
+function getDistSquared(x1,y1,x2,y2){
+  let a = x2-x1;
+  let b = y2-y1;
+  return a*a + b*b;
+}
+
+// Ball Class
+class Ball {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+    this.velocityX = random(-0.2,0.2);
+    this.velocityY = random(-0.2,0.2);
+    this.color = color(0, 0, 0);
+    this.selected = false;
+  }
+
+  display() {
+    if (this.selected) {
+      fill(255, 255, 0);
+    } else {
+      noFill();
+    }
+
+    strokeWeight(0.5);
+    ellipse(this.x, this.y, 5, 5);
+  }
+
+  move() {
+    this.x += this.velocityX;
+    this.y += this.velocityY;
+    let buffer = 20;
+    if (this.x > (width / 2) - buffer || this.x < (-width / 2) + buffer) {
+      this.velocityX *= -1;
+    }
+    if (this.y > (height / 2) - buffer || this.y < (-height / 2) + buffer) {
+      this.velocityY *= -1;
+    }
+  }
+}

--- a/src/p5sketches.js
+++ b/src/p5sketches.js
@@ -17,15 +17,27 @@ myCoolSketch = (sketch) => {
 
 // create a location for this sketch in the scene:
 location = {
-  x: -14,
+  x: -8,
   y: 1.5,
-  z: -14,
+  z: -8,
 };
+size = {
+  x: 1,
+  y: 1,
+  z: 1
+}
+rotation = {
+  x: 0,
+  y: 0,
+  z: 0
+}
 
 // Add this sketch to the array:
 sketches.push({
   sketch: myCoolSketch,
   location: location,
+  size: size,
+  rotation: rotation
 });
 
 //*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
@@ -63,14 +75,26 @@ myCoolSketch = (sketch) => {
 };
 
 location = {
-  x: -16,
+  x: -8,
   y: 2,
-  z: -12,
+  z: -18,
 };
+size = {
+  x: 2,
+  y: 2,
+  z: 0.05
+}
+rotation = {
+  x: 0,
+  y: 0,
+  z: 0
+}
 // Add this sketch to the array:
 sketches.push({
   sketch: myCoolSketch,
   location: location,
+  size: size,
+  rotation: rotation
 });
 
 //*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//

--- a/src/p5sketches.js
+++ b/src/p5sketches.js
@@ -1,0 +1,198 @@
+let sketches = [];
+let myCoolSketch, location;
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+// My cool sketch!
+myCoolSketch = (sketch) => {
+  sketch.setup = () => {
+    sketch.createCanvas(100, 100, sketch.WEBGL);
+  };
+
+  sketch.draw = () => {
+    sketch.background(205, 105, 94);
+    sketch.rotateY(sketch.millis() / 1000);
+    sketch.sphere(40, 16, 3);
+  };
+};
+
+// create a location for this sketch in the scene:
+location = {
+  x: -14,
+  y: 1.5,
+  z: -14,
+};
+
+// Add this sketch to the array:
+sketches.push({
+  sketch: myCoolSketch,
+  location: location,
+});
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+// Bouncing Ball Sketch
+myCoolSketch = (sketch) => {
+  let ballX = 100;
+  let ballY = 100;
+  let velocityX = sketch.random(-5, 5);
+  let velocityY = sketch.random(-5, 5);
+  let buffer = 25;
+
+  sketch.setup = () => {
+    sketch.createCanvas(400, 400);
+    ballX = sketch.width / 2;
+    ballY = sketch.height / 2;
+    sketch.pixelDensity(1);
+    sketch.frameRate(25);
+    sketch.rectMode(sketch.CENTER);
+    sketch.ellipseMode(sketch.CENTER);
+  };
+
+  sketch.draw = () => {
+    sketch.background(10, 10, 200);
+    ballX += velocityX;
+    ballY += velocityY;
+    if (ballX >= sketch.width - buffer || ballX <= buffer) {
+      velocityX = -velocityX;
+    }
+    if (ballY >= sketch.height - buffer || ballY <= buffer) {
+      velocityY = -velocityY;
+    }
+    sketch.fill(240, 120, 0);
+    sketch.ellipse(ballX, ballY, 50, 50);
+  };
+};
+
+location = {
+  x: -16,
+  y: 2,
+  z: -12,
+};
+// Add this sketch to the array:
+sketches.push({
+  sketch: myCoolSketch,
+  location: location,
+});
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+
+// myCoolSketch = (sketch) => {
+//     // add sketch 'definition' here
+// }
+// // where should the sketch end up in the scene:
+// location = {
+//     x: 0,
+//     y: 0,
+//     z: 0
+// }
+// // Add this sketch to the array:
+// sketches.push({
+//     sketch: mySketch,
+//     location: location,
+//   });
+
+//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//*//
+// this makes the sketches available to the scene:
+module.exports = sketches;

--- a/src/scene.js
+++ b/src/scene.js
@@ -12,6 +12,7 @@ const THREE = require('./libs/three.min.js');
 const Stats = require('./libs/stats.min.js');
 
 const p5 = require('p5');
+const p5sketches = require('./p5sketches');
 
 // slightly awkward syntax, but these statements add these functions to THREE
 require('./libs/GLTFLoader.js')(THREE);
@@ -1914,55 +1915,11 @@ class Scene {
 
 
 	addSketches(){
-		const s = (sketch) => {
-			
-			sketch.setup = ()=> {
-				sketch.createCanvas(100, 100, sketch.WEBGL);
-			  };
-			  
-			sketch.draw = () => {
-				sketch.background(205, 105, 94);
-				sketch.rotateY(sketch.millis() / 1000);
-				sketch.sphere(40, 16, 3);
-			  };
-		};
-
-		this.addSketchToScene(s, -14,1.5,-14);
-
-
-		const s1 = (sketch) => {
-			let ballX = 100;
-			let ballY = 100;
-			let velocityX = sketch.random(-5, 5);
-			let velocityY = sketch.random(-5, 5);
-			let buffer = 25;
-	
-			sketch.setup = () => {
-				sketch.createCanvas(400, 400);
-				ballX = sketch.width / 2;
-				ballY = sketch.height / 2;
-				sketch.pixelDensity(1);
-				sketch.frameRate(25);
-				sketch.rectMode(sketch.CENTER);
-				sketch.ellipseMode(sketch.CENTER);
-			};
-	
-			sketch.draw = () => {
-				sketch.background(10, 10, 200);
-				ballX += velocityX;
-				ballY += velocityY;
-				if (ballX >= (sketch.width - buffer) || ballX <= buffer) {
-					velocityX = -velocityX;
-				}
-				if (ballY >= (sketch.height - buffer) || ballY <= buffer) {
-					velocityY = -velocityY;
-				}
-				sketch.fill(240, 120, 0);
-				sketch.ellipse(ballX, ballY, 50, 50);
-			};
-		};
-
-		this.addSketchToScene(s1, -11,1.5,-9);
+		console.log("Adding p5.js sketches to the scene!");
+		for (let i = 0; i < p5sketches.length; i++){
+			const sketchAndLocation = p5sketches[i];
+			this.addSketchToScene(sketchAndLocation.sketch, sketchAndLocation.location);
+		}
 	}
 	/**
 	 * 
@@ -1973,7 +1930,7 @@ class Scene {
 	 * applies canvasTexture to material on that plane
 	 * 
 	 */
-	addSketchToScene(sketchDefinition,x,y,z){
+	addSketchToScene(sketchDefinition,location){
 		
 		const sketch = new p5(sketchDefinition);
 		console.log(sketch);
@@ -2001,7 +1958,7 @@ class Scene {
 			videoMaterial
 		);
 
-		sketchBox.position.set(x,y,z);
+		sketchBox.position.set(location.x,location.y,location.z);
 		this.scene.add(sketchBox);
 	}
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -1923,8 +1923,8 @@ class Scene {
 		console.log(canvas);
 
 		for (let i = 0; i < p5sketches.length; i++){
-			const sketchAndLocation = p5sketches[i];
-			this.addSketchToScene(sketchAndLocation.sketch, sketchAndLocation.location);
+			const info = p5sketches[i];
+			this.addSketchToScene(info.sketch, info.location,info.size,info.rotation);
 		}
 
 		let el = document.createElement('iframe');
@@ -1941,7 +1941,7 @@ class Scene {
 	 * applies canvasTexture to material on that plane
 	 * 
 	 */
-	addSketchToScene(sketchDefinition,location){
+	addSketchToScene(sketchDefinition,location, size, rotation){
 		
 		const sketch = new p5(sketchDefinition);
 		console.log(sketch);
@@ -1965,7 +1965,7 @@ class Scene {
 
 		this.updateableVideoTextures.push(videoTexture)
 		let sketchBox = new THREE.Mesh(
-			new THREE.BoxGeometry(2,2,2),
+			new THREE.BoxGeometry(size.x,size.y,size.z),
 			videoMaterial
 		);
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -1920,6 +1920,11 @@ class Scene {
 			const sketchAndLocation = p5sketches[i];
 			this.addSketchToScene(sketchAndLocation.sketch, sketchAndLocation.location);
 		}
+
+		let el = document.createElement('iframe');
+		el.setAttribute('src', 'https://editor.p5js.org/p5/embed/rBqmyGZlS9');
+		el.setAttribute('id', 'myiframe');
+		document.body.appendChild(el);
 	}
 	/**
 	 * 

--- a/src/scene.js
+++ b/src/scene.js
@@ -1916,6 +1916,12 @@ class Scene {
 
 	addSketches(){
 		console.log("Adding p5.js sketches to the scene!");
+
+		let sketchFrame = document.getElementById('sketchFrame');
+		console.log(sketchFrame);
+		let canvas = sketchFrame.contentDocument.getElementById('defaultCanvas0');
+		console.log(canvas);
+
 		for (let i = 0; i < p5sketches.length; i++){
 			const sketchAndLocation = p5sketches[i];
 			this.addSketchToScene(sketchAndLocation.sketch, sketchAndLocation.location);


### PR DESCRIPTION
#### This pull request will add the following functionality:
* `addSketchToScene` will take a p5 sketch instance 'closure' (as covered in this [p5 wiki page](https://github.com/processing/p5.js/wiki/Global-and-instance-mode)) and an X,Y,Z position as an argument, and instantiate a THREE.js Mesh into the scene at that point with the p5 sketch running on all sides.  Internally, this does the following:
    * creates a p5 instance with a canvas,
    * uses that p5 instance's canvas to create a videoTexture and videoMaterial,
    * creates a THREE.js Mesh using that videoMaterial

* `updateSketches` will run in the scene's update loop and will update each p5 sketch's corresponding videoTexture so that the various THREE.js Meshes with p5 sketches on them stay in-sync with the p5 sketch


####  To Do:
- [x] - allow different aspect ratios of sketches,
- [x] - allow different size and shape of THREE.js Meshes on which the sketch will be displayed?
- [ ] - where to pull p5 sketches from?  another file? a whole folder?
- [ ] - only run sketch when you are close to it in three.js scene? use loop/noloop
- [ ] - iframe from p5 web editor
- [ ] - transparent material
