### PR TITLE
Return to Lobby

### DIFF
--- a/src/js/portals.js
+++ b/src/js/portals.js
@@ -8,7 +8,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 const PortalModels = require('../assets/models/portals/*.glb');
 //this reference holds all info about which portal goes to where, used by both yorblet.js and winterShow2020.js
 const yorbletReference = [
-    {url: "https://yorb.itp.io", model: PortalModels['tacobell'], label: {text:"Go back to Lobby", color:0xf4d010, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:3}}, //lobby
+    {url: "https://yorb.itp.io", model: PortalModels['tacobell'], label: {text:"Return to Lobby", color:0xf4d010, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:2}}, //lobby
     {url: 'https://yorblet1.itp.io', model: PortalModels['sphBlue'], label: {text:"Go to Yorblet 1", color:0x4b4ff4, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:3}},
     {url: 'https://yorblet2.itp.io', model: PortalModels['cubPink'], label: {text:"Go to Yorblet 2", color:0xfc3691, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:3}},
     {url: 'https://yorblet3.itp.io', model: PortalModels['pyrYellow'], label: {text:"Go to Yorblet 3", color:0xf4d010, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:3}},
@@ -21,7 +21,7 @@ const yorbletReference = [
     {url: 'https://yorblet10.itp.io', model: PortalModels['cubBlue'], label: {text:"Go to Yorblet 10", color:0x4b4ff4, size:0.4, rotateY:Math.PI / 2, xOff:0, yOff:3, zOff:3}},
 ]
 
-//yorblet.js uses yorblet_index, which gets passed here to 
+//yorblet.js uses yorblet_index, which gets passed here to
 //the portal trigger is checked in the update method of yorb.js
 export class Portal {
     // constructor(scene, portal, destination, label) {
@@ -75,7 +75,7 @@ export class Portal {
                 const fontMesh = new THREE.Mesh(fontGeometry, fontMaterial)
                 fontMesh.rotateY(this.label.rotateY)
                 fontMesh.position.set(this.position.x + this.label.xOff, this.position.y + this.label.yOff, this.position.z +  + this.label.zOff) // make it floating right above the portal shape
-                
+
                 this.scene.add(fontMesh)
             },
             undefined,
@@ -90,7 +90,7 @@ export class Portal {
         //needed to convert because getPlayerPosition doesn't return a vec3
         let userVec3 = new Vector3(userPosition[0], userPosition[1], userPosition[2]);
         console.log(this.position.distanceTo(userVec3));
-        
+
         if (this.position.distanceTo(userVec3) <= this.radius) {
             console.log('teleporting');
             //if doing modal, would need to do so here, but would have to change the return timing


### PR DESCRIPTION
Moved the text to be more centered over the portal and changed it to "Return to Lobby" instead of "Go back to Lobby".  

I know the theme is to use "Go" for all the portals but "Return" seemed to make more sense and looked better than "Go back".